### PR TITLE
Update documentation to clarify date comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Processing and manipulation of date intervals
 
 **DateRange** represents an **inclusive** range of dates. It is defined by two time.Time values, `from` and `to`.
 
+**Note:** Only the date portion of the time.Time values is compared. The time portion is ignored.
 
 #### Constructors
 

--- a/date_range.go
+++ b/date_range.go
@@ -40,6 +40,7 @@ type DateRange struct {
 // order input dates and truncates the time portion of the dates, ignoring the
 // time zone (for example 2024-01-26 9pm EST will still be the 26th of January 2024).
 // Use MustNewDateRange if you want to panic if `from` date if after the `to`date .
+// Note: Only the date portion of the time.Time values is compared. The time portion is ignored.
 func NewDateRange(from, to time.Time) DateRange {
 	from = toDateUTC(from)
 	to = toDateUTC(to)
@@ -54,6 +55,7 @@ func NewDateRange(from, to time.Time) DateRange {
 // 2024-01-26 9pm EST will still be the 26th of January 2024). This panics if the
 // truncated `from` date is after the truncated `to` date.
 // Use NewDateRange if you want to automatically order input dates.
+// Note: Only the date portion of the time.Time values is compared. The time portion is ignored.
 func MustNewDateRange(from, to time.Time) DateRange {
 	from = toDateUTC(from)
 	to = toDateUTC(to)

--- a/doc.go
+++ b/doc.go
@@ -27,4 +27,6 @@ SOFTWARE.
 // date intervals efficiently and effectively. This library simplifies operations
 // such as comparing dates, checking overlaps, and processing date ranges in Go
 // applications.
+//
+// Note: Only the date portion of the time.Time values is compared. The time portion is ignored.
 package daterange


### PR DESCRIPTION
Fixes #22

Add a note explaining that only the date portion is compared.

* **README.md**
  - Add a note explaining that only the date portion of the time.Time values is compared. The time portion is ignored.

* **doc.go**
  - Add a note about ignoring the time portion of dates.

* **date_range.go**
  - Explicitly state in the function comments that only the date portion is compared.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/FelixEnescu/date-range/pull/24?shareId=7c5e3dc7-8414-44a0-8559-bb29d149ef36).